### PR TITLE
fix: unnecessary remap to select-mode which disturbs nvim-snippy

### DIFF
--- a/doc/gx-extended.txt
+++ b/doc/gx-extended.txt
@@ -115,7 +115,7 @@ If you don't define these mappings, `gx` is used by default.
 
 >
     nmap gx <Plug>(gxext-normal)
-    vmap gx <Plug>(gxext-visual)
+    xmap gx <Plug>(gxext-visual)
 <
 
 ==============================================================================

--- a/plugin/gxext.vim
+++ b/plugin/gxext.vim
@@ -8,8 +8,8 @@ vnoremap <unique><silent> <Plug>(gxext-visual) :<C-U>call gxext#visual()<CR>
 if maparg('gx','n') == '' && !hasmapto('<Plug>(gxext-normal)')
   nmap gx <Plug>(gxext-normal)
 endif
-if maparg('gx', 'v') == '' && !hasmapto('<Plug>(gxext-visual)')
-  vmap gx <Plug>(gxext-visual)
+if maparg('gx', 'x') == '' && !hasmapto('<Plug>(gxext-visual)')
+  xmap gx <Plug>(gxext-visual)
 endif
 
 let g:gxext#debug = get(g:, 'gxext#debug', 0)

--- a/tests/init.vim
+++ b/tests/init.vim
@@ -5,4 +5,4 @@ let g:gxext#debug = 1
 let g:gxext#dryrun = 1
 
 nmap gx <Plug>(gxext-normal)
-vmap gx <Plug>(gxext-visual)
+xmap gx <Plug>(gxext-visual)


### PR DESCRIPTION
`vmap` is used to map `gx` to visual-mode. However, `vmap` not only maps to visual-mode but also select-mode. This is first of all not necessary because `xmap` is enough to map to visual-mode but more importantly it disturbs other plugins which rely on select-mode like `nvim-snippy`. During snippet-expansion snippy selects with the select-mode placeholders which should be overwritten by the user. Typing `g` becomes impossible without pressing another 2nd key because it's remapped by gx-extended. It is generally good practice to use xmap instead of vmap unless necessary.